### PR TITLE
Refactor events into separate modules

### DIFF
--- a/src/commands/muteall.ts
+++ b/src/commands/muteall.ts
@@ -4,7 +4,7 @@ import {
   GuildMember,
   PermissionsBitField,
 } from "discord.js";
-import { setLockInModeStartedTimestamp } from "..";
+import { setLockInModeStartedTimestamp } from "../state/muteState";
 
 export default {
   data: new SlashCommandBuilder()

--- a/src/commands/random.ts
+++ b/src/commands/random.ts
@@ -4,7 +4,7 @@ import {
   GuildMember,
   PermissionsBitField,
 } from "discord.js";
-import { setLockInModeStartedTimestamp } from "..";
+import { setLockInModeStartedTimestamp } from "../state/muteState";
 
 export const randomCommand = {
   data: new SlashCommandBuilder()

--- a/src/commands/timeleft.ts
+++ b/src/commands/timeleft.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction } from "discord.js";
-import { timeouts } from "..";
+import { timeouts } from "../state/muteState";
 
 export default {
   data: new SlashCommandBuilder()

--- a/src/commands/unc.ts
+++ b/src/commands/unc.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction } from "discord.js";
-import { timeouts } from "..";
+import { timeouts } from "../state/muteState";
 
 const ANDREW_BIRTHDAY_TIMESTAMP = new Date("2025-06-16T00:00:00-06:00");
 

--- a/src/commands/vanished.ts
+++ b/src/commands/vanished.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction } from "discord.js";
-import { timeouts } from "..";
+import { timeouts } from "../state/muteState";
 
 const VANISHED_TIMESTAMP = new Date("2024-11-19T10:34:00-06:00");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,10 @@
 import {
   Client,
   GatewayIntentBits,
-  GuildMember,
-  Message,
-  type Interaction,
 } from "discord.js";
 import { REST } from "@discordjs/rest";
 import { Routes } from "discord-api-types/v9";
 import dotenv from "dotenv";
-import { Config } from "./config";
-import { cancelTimer, startTimer } from "./utils/LockinTimer";
 import { pingCommand } from "./commands/ping";
 import playCommand from "./commands/play";
 import pauseCommand from "./commands/pause";
@@ -22,9 +17,6 @@ import loopCommand from "./commands/loop";
 import djmodeCommand from "./commands/djmode";
 import muteAllCommand from "./commands/muteall";
 import removeCommand from "./commands/remove";
-import { isInChannel } from "./utils/isInChannel";
-import mutedDuration from "./constants/mutedDuration";
-import ttsRole from "./constants/ttsRole";
 import jumpCommand from "./commands/jump";
 import { lockInCommand } from "./commands/lockin";
 import { unlockCommand } from "./commands/unlock";
@@ -32,6 +24,9 @@ import ttsCommand from "./commands/tts";
 import { randomCommand } from "./commands/random";
 import vanishedCommand from "./commands/vanished";
 import uncCommand from "./commands/unc";
+import { createInteractionHandler } from "./routes/interactionCreate";
+import { readyHandler } from "./routes/ready";
+import { handleVoiceStateUpdate } from "./routes/voiceStateUpdate";
 
 dotenv.config();
 
@@ -62,31 +57,10 @@ const commands = [
   ...musicBotCommands,
 ];
 
-function isMusicBotCommand(commandName: string): boolean {
-  return musicBotCommands.some((command) => command.data.name === commandName);
-}
-
-client.on("interactionCreate", async (interaction: Interaction) => {
-  if (!interaction.isCommand()) return;
-
-  const { commandName } = interaction;
-
-  for (const command of commands) {
-    if (command.data.name === commandName) {
-      if (isMusicBotCommand(command.data.name)) {
-        const inChannel = isInChannel(interaction);
-
-        if (!inChannel) {
-          return interaction.editReply(
-            "You need to be in a voice channel to play music!"
-          );
-        }
-      }
-
-      await command.execute(interaction);
-    }
-  }
-});
+client.on(
+  "interactionCreate",
+  createInteractionHandler(commands, musicBotCommands)
+);
 
 const rest = new REST({ version: "10" }).setToken(
   process.env.DISCORD_TOKEN as string
@@ -109,182 +83,6 @@ const rest = new REST({ version: "10" }).setToken(
 
 client.login(process.env.DISCORD_TOKEN);
 
-client.once("ready", () => {
-  console.log("Bot is online!");
-});
+client.once("ready", readyHandler);
 
-export const timeouts = new Map<
-  string,
-  { timer: Timer; timestamp: number; message?: Message; tts?: boolean }
->();
-const remainingTimeouts = new Map<
-  string,
-  { timeRemaining: number; tts?: boolean }
->();
-export let lockInModeStartedTimestamp = 0;
-
-export function setLockInModeStartedTimestamp(timestamp: number) {
-  lockInModeStartedTimestamp = timestamp;
-
-  setTimeout(() => {
-    lockInModeStartedTimestamp = 0;
-  }, 1000 * 60 * 5);
-}
-
-client.on("voiceStateUpdate", async (oldState, newState) => {
-  const member = newState.member as GuildMember;
-  const userId = member.id;
-  const isMuted = member.voice.mute;
-
-  const hasBeenMuted = !oldState.serverMute && newState.serverMute;
-  const hasBeenUnmuted = oldState.serverMute && !newState.serverMute;
-
-  if (!member || !newState.guild) return;
-  if (member.user.bot) return;
-
-  const isInLockedVC =
-    newState.channelId && Config.lockedVCIds.includes(newState.channelId);
-  const hasStartedStreaming = !oldState.streaming && newState.streaming;
-  const hasStoppedStreaming = oldState.streaming && !newState.streaming;
-  const hasMuteRole = member.roles.cache.has(Config.muteRoleId);
-
-  const hasJoinedVC = !oldState.channelId && newState.channelId;
-  const hasLeftVC = oldState.channelId && !newState.channelId;
-
-  if (hasMuteRole) {
-    const shouldBeMuted = Boolean(isInLockedVC);
-    if (isMuted !== shouldBeMuted) {
-      await member.voice.setMute(shouldBeMuted);
-    }
-
-    if (isInLockedVC && hasStartedStreaming) {
-      startTimer(userId, member);
-    }
-
-    if (hasStoppedStreaming || hasLeftVC) {
-      cancelTimer(userId);
-    }
-  } else if (hasBeenMuted) {
-    const lockInModeTimeRemaining =
-      (lockInModeStartedTimestamp - Date.now()) / (1000 * 60);
-    const waitMinutes =
-      lockInModeTimeRemaining > 0 ? lockInModeTimeRemaining : mutedDuration;
-    const waitDuration = 60 * waitMinutes * 1000;
-
-    const timeout = timeouts.get(userId);
-    if (timeout) {
-      clearTimeout(timeout.timer);
-      timeouts.delete(userId);
-    }
-
-    const channel = member.voice.channel;
-    let sentMessage: Message | undefined = undefined;
-    const roundedWaitMinutes = Math.round(waitMinutes);
-    if (channel) {
-      sentMessage = await channel.send(
-        `<@${
-          member.id
-        }> has been muted for ${roundedWaitMinutes} minutes.\nUnmuting <t:${Math.floor(
-          (Date.now() + waitDuration) / 1000
-        )}:R>`
-      );
-    }
-    const tts = member.roles.cache.has(ttsRole);
-    if (tts) {
-      member.roles.remove(ttsRole);
-    }
-
-    const createdTimeout = setTimeout(() => {
-      timeouts.delete(userId);
-      if (!member.voice.channelId) return;
-      member.voice?.setMute(false);
-
-      if (tts) {
-        member.roles.add(ttsRole);
-      }
-
-      if (sentMessage) {
-        sentMessage.edit(`${member.user.displayName} has been unmuted.`);
-      }
-    }, waitDuration);
-
-    timeouts.set(userId, {
-      timer: createdTimeout,
-      timestamp: Date.now() + waitDuration,
-      message: sentMessage,
-      tts,
-    });
-  } else if (hasBeenUnmuted) {
-    const timeout = timeouts.get(userId);
-    const tts = timeout?.tts;
-    if (timeout) {
-      if (tts) {
-        member.roles.add(ttsRole);
-      }
-      timeout.message?.edit(`${member.user.displayName} has been unmuted.`);
-      timeouts.delete(userId);
-      clearTimeout(timeout.timer);
-    }
-  } else if (hasJoinedVC) {
-    const remainingTimeout = remainingTimeouts.get(userId);
-    const isLockInMode = lockInModeStartedTimestamp > Date.now();
-    const lockInModeTimeRemaining =
-      (lockInModeStartedTimestamp - Date.now()) / (1000 * 60);
-    const tts = remainingTimeout?.tts;
-    if (!remainingTimeout && !isLockInMode) return;
-
-    if (!newState.serverMute && isLockInMode) {
-      member.voice?.setMute(true);
-      return;
-    }
-
-    const timeRemaining =
-      remainingTimeout?.timeRemaining || lockInModeTimeRemaining;
-
-    const channel = member.voice.channel;
-    if (!channel) return;
-
-    remainingTimeouts.delete(userId);
-
-    let sentMessage = await channel.send(
-      `<@${member.id}> is still muted.\nUnmuting <t:${Math.floor(
-        (Date.now() + timeRemaining) / 1000
-      )}:R>`
-    );
-
-    const createdTimeout = setTimeout(() => {
-      timeouts.delete(userId);
-      if (!member.voice.channelId) return;
-      member.voice?.setMute(false);
-
-      if (tts) {
-        member.roles.add(ttsRole);
-      }
-
-      sentMessage.edit(`${member.user.displayName} has been unmuted.`);
-    }, timeRemaining);
-
-    timeouts.set(userId, {
-      timer: createdTimeout,
-      timestamp: Date.now() + timeRemaining,
-      message: sentMessage,
-      tts,
-    });
-  } else if (hasLeftVC) {
-    const timeout = timeouts.get(userId);
-    const tts = timeout?.tts;
-    if (timeout) {
-      remainingTimeouts.set(userId, {
-        timeRemaining: timeout.timestamp - Date.now(),
-        tts,
-      });
-
-      timeout.message?.edit(
-        `${member.user.displayName} left the voice channel.`
-      );
-
-      timeouts.delete(userId);
-      clearTimeout(timeout.timer);
-    }
-  }
-});
+client.on("voiceStateUpdate", handleVoiceStateUpdate);

--- a/src/routes/interactionCreate.ts
+++ b/src/routes/interactionCreate.ts
@@ -1,0 +1,33 @@
+import type { Interaction } from "discord.js";
+import { isInChannel } from "../utils/isInChannel";
+
+export function createInteractionHandler(
+  commands: any[],
+  musicBotCommands: any[]
+) {
+  function isMusicBotCommand(commandName: string): boolean {
+    return musicBotCommands.some((cmd) => cmd.data.name === commandName);
+  }
+
+  return async function handleInteraction(interaction: Interaction) {
+    if (!interaction.isCommand()) return;
+
+    const { commandName } = interaction;
+
+    for (const command of commands) {
+      if (command.data.name === commandName) {
+        if (isMusicBotCommand(command.data.name)) {
+          const inChannel = isInChannel(interaction);
+
+          if (!inChannel) {
+            return interaction.editReply(
+              "You need to be in a voice channel to play music!"
+            );
+          }
+        }
+
+        await command.execute(interaction);
+      }
+    }
+  };
+}

--- a/src/routes/ready.ts
+++ b/src/routes/ready.ts
@@ -1,0 +1,3 @@
+export function readyHandler() {
+  console.log("Bot is online!");
+}

--- a/src/routes/voiceStateUpdate.ts
+++ b/src/routes/voiceStateUpdate.ts
@@ -1,0 +1,169 @@
+import { GuildMember, Message, VoiceState } from "discord.js";
+import { Config } from "../config";
+import { cancelTimer, startTimer } from "../utils/LockinTimer";
+import mutedDuration from "../constants/mutedDuration";
+import ttsRole from "../constants/ttsRole";
+import {
+  timeouts,
+  remainingTimeouts,
+  lockInModeStartedTimestamp,
+} from "../state/muteState";
+
+export async function handleVoiceStateUpdate(
+  oldState: VoiceState,
+  newState: VoiceState
+) {
+  const member = newState.member as GuildMember;
+  const userId = member.id;
+  const isMuted = member.voice.mute;
+
+  const hasBeenMuted = !oldState.serverMute && newState.serverMute;
+  const hasBeenUnmuted = oldState.serverMute && !newState.serverMute;
+
+  if (!member || !newState.guild) return;
+  if (member.user.bot) return;
+
+  const isInLockedVC =
+    newState.channelId && Config.lockedVCIds.includes(newState.channelId);
+  const hasStartedStreaming = !oldState.streaming && newState.streaming;
+  const hasStoppedStreaming = oldState.streaming && !newState.streaming;
+  const hasMuteRole = member.roles.cache.has(Config.muteRoleId);
+
+  const hasJoinedVC = !oldState.channelId && newState.channelId;
+  const hasLeftVC = oldState.channelId && !newState.channelId;
+
+  if (hasMuteRole) {
+    const shouldBeMuted = Boolean(isInLockedVC);
+    if (isMuted !== shouldBeMuted) {
+      await member.voice.setMute(shouldBeMuted);
+    }
+
+    if (isInLockedVC && hasStartedStreaming) {
+      startTimer(userId, member);
+    }
+
+    if (hasStoppedStreaming || hasLeftVC) {
+      cancelTimer(userId);
+    }
+  } else if (hasBeenMuted) {
+    const lockInModeTimeRemaining =
+      (lockInModeStartedTimestamp - Date.now()) / (1000 * 60);
+    const waitMinutes =
+      lockInModeTimeRemaining > 0 ? lockInModeTimeRemaining : mutedDuration;
+    const waitDuration = 60 * waitMinutes * 1000;
+
+    const timeout = timeouts.get(userId);
+    if (timeout) {
+      clearTimeout(timeout.timer);
+      timeouts.delete(userId);
+    }
+
+    const channel = member.voice.channel;
+    let sentMessage: Message | undefined = undefined;
+    const roundedWaitMinutes = Math.round(waitMinutes);
+    if (channel) {
+      sentMessage = await channel.send(
+        `<@${member.id}> has been muted for ${roundedWaitMinutes} minutes.\nUnmuting <t:${Math.floor(
+          (Date.now() + waitDuration) / 1000
+        )}:R>`
+      );
+    }
+    const tts = member.roles.cache.has(ttsRole);
+    if (tts) {
+      member.roles.remove(ttsRole);
+    }
+
+    const createdTimeout = setTimeout(() => {
+      timeouts.delete(userId);
+      if (!member.voice.channelId) return;
+      member.voice?.setMute(false);
+
+      if (tts) {
+        member.roles.add(ttsRole);
+      }
+
+      if (sentMessage) {
+        sentMessage.edit(`${member.user.displayName} has been unmuted.`);
+      }
+    }, waitDuration);
+
+    timeouts.set(userId, {
+      timer: createdTimeout,
+      timestamp: Date.now() + waitDuration,
+      message: sentMessage,
+      tts,
+    });
+  } else if (hasBeenUnmuted) {
+    const timeout = timeouts.get(userId);
+    const tts = timeout?.tts;
+    if (timeout) {
+      if (tts) {
+        member.roles.add(ttsRole);
+      }
+      timeout.message?.edit(`${member.user.displayName} has been unmuted.`);
+      timeouts.delete(userId);
+      clearTimeout(timeout.timer);
+    }
+  } else if (hasJoinedVC) {
+    const remainingTimeout = remainingTimeouts.get(userId);
+    const isLockInMode = lockInModeStartedTimestamp > Date.now();
+    const lockInModeTimeRemaining =
+      (lockInModeStartedTimestamp - Date.now()) / (1000 * 60);
+    const tts = remainingTimeout?.tts;
+    if (!remainingTimeout && !isLockInMode) return;
+
+    if (!newState.serverMute && isLockInMode) {
+      member.voice?.setMute(true);
+      return;
+    }
+
+    const timeRemaining =
+      remainingTimeout?.timeRemaining || lockInModeTimeRemaining;
+
+    const channel = member.voice.channel;
+    if (!channel) return;
+
+    remainingTimeouts.delete(userId);
+
+    let sentMessage = await channel.send(
+      `<@${member.id}> is still muted.\nUnmuting <t:${Math.floor(
+        (Date.now() + timeRemaining) / 1000
+      )}:R>`
+    );
+
+    const createdTimeout = setTimeout(() => {
+      timeouts.delete(userId);
+      if (!member.voice.channelId) return;
+      member.voice?.setMute(false);
+
+      if (tts) {
+        member.roles.add(ttsRole);
+      }
+
+      sentMessage.edit(`${member.user.displayName} has been unmuted.`);
+    }, timeRemaining);
+
+    timeouts.set(userId, {
+      timer: createdTimeout,
+      timestamp: Date.now() + timeRemaining,
+      message: sentMessage,
+      tts,
+    });
+  } else if (hasLeftVC) {
+    const timeout = timeouts.get(userId);
+    const tts = timeout?.tts;
+    if (timeout) {
+      remainingTimeouts.set(userId, {
+        timeRemaining: timeout.timestamp - Date.now(),
+        tts,
+      });
+
+      timeout.message?.edit(
+        `${member.user.displayName} left the voice channel.`
+      );
+
+      timeouts.delete(userId);
+      clearTimeout(timeout.timer);
+    }
+  }
+}

--- a/src/state/muteState.ts
+++ b/src/state/muteState.ts
@@ -1,0 +1,21 @@
+import { Message } from "discord.js";
+
+export const timeouts = new Map<
+  string,
+  { timer: Timer; timestamp: number; message?: Message; tts?: boolean }
+>();
+
+export const remainingTimeouts = new Map<
+  string,
+  { timeRemaining: number; tts?: boolean }
+>();
+
+export let lockInModeStartedTimestamp = 0;
+
+export function setLockInModeStartedTimestamp(timestamp: number) {
+  lockInModeStartedTimestamp = timestamp;
+
+  setTimeout(() => {
+    lockInModeStartedTimestamp = 0;
+  }, 1000 * 60 * 5);
+}


### PR DESCRIPTION
## Summary
- refactor interaction, ready, and voice events into separate files
- move mute related state to its own module
- update imports in commands

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845f8b3077c83289735fdd5a298a82d